### PR TITLE
Fix #1 (status vs list count drift) and #2 (no prefix match in search)

### DIFF
--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -65,8 +65,8 @@ SHA-1 has changed since the previous run.`,
 				repoCanon, _ := canonicalPath(repoRoot)
 				if canon == repoCanon {
 					e.LastIndexed = sum.IndexedAt
-					e.FileCount = sum.Parsed + sum.Skipped
-					e.SymbolCount = sum.Symbols
+					e.FileCount = sum.TotalFiles
+					e.SymbolCount = sum.TotalSymbols
 					_ = reg.Upsert(e)
 					break
 				}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -71,8 +71,8 @@ on an already-initialised repository.`,
 
 			// Update registry mirror with results.
 			entry.LastIndexed = sum.IndexedAt
-			entry.FileCount = sum.Parsed + sum.Skipped
-			entry.SymbolCount = sum.Symbols
+			entry.FileCount = sum.TotalFiles
+			entry.SymbolCount = sum.TotalSymbols
 			if err := reg.Upsert(entry); err != nil {
 				return fmt.Errorf("init: update registry: %w", err)
 			}

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -66,8 +66,8 @@ corrupted.`,
 				repoCanon, _ := canonicalPath(repoRoot)
 				if canon == repoCanon {
 					e.LastIndexed = sum.IndexedAt
-					e.FileCount = sum.Parsed + sum.Skipped
-					e.SymbolCount = sum.Symbols
+					e.FileCount = sum.TotalFiles
+					e.SymbolCount = sum.TotalSymbols
 					_ = reg.Upsert(e)
 					break
 				}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -48,6 +48,14 @@ type Summary struct {
 	Symbols int
 	// Edges is the total number of edges inserted in this run.
 	Edges int
+	// TotalSymbols is the cumulative symbol count in the index after this run
+	// (matches the value written to meta.symbol_count). Use this — not
+	// Symbols — when mirroring counts into the registry so that `status`
+	// (reads SQLite meta) and `list` (reads registry) agree.
+	TotalSymbols int
+	// TotalFiles is the cumulative file count in the index after this run
+	// (matches meta.file_count). Same rationale as TotalSymbols.
+	TotalFiles int
 	// Duration is the wall-clock time for the full indexing pass.
 	Duration time.Duration
 	// IndexedAt is the UTC timestamp written to the meta table.
@@ -102,6 +110,7 @@ func Index(ctx context.Context, st *store.Store, repoRoot string, opts IndexOpti
 	// --- 4. Fast path: nothing to do. ---
 	if len(changed) == 0 && len(removed) == 0 && !opts.Force {
 		now := time.Now().UTC()
+		var fastSymbols, fastFiles int
 		// Still write updated indexed_at.
 		if err := st.WithTx(ctx, func(tx store.Tx) error {
 			meta, err := tx.ReadMeta()
@@ -109,14 +118,18 @@ func Index(ctx context.Context, st *store.Store, repoRoot string, opts IndexOpti
 				return err
 			}
 			meta.IndexedAt = now
+			fastSymbols = meta.SymbolCount
+			fastFiles = meta.FileCount
 			return tx.WriteMeta(meta)
 		}); err != nil {
 			return Summary{}, fmt.Errorf("pipeline.Index: update meta (no-op): %w", err)
 		}
 		return Summary{
-			Skipped:   len(prev),
-			Duration:  time.Since(start),
-			IndexedAt: now,
+			Skipped:      len(prev),
+			TotalSymbols: fastSymbols,
+			TotalFiles:   fastFiles,
+			Duration:     time.Since(start),
+			IndexedAt:    now,
 		}, nil
 	}
 
@@ -188,6 +201,7 @@ func Index(ctx context.Context, st *store.Store, repoRoot string, opts IndexOpti
 	// --- 8. Single transaction: delete removed, upsert changed. ---
 	now := time.Now().UTC()
 	var totalSymbols, totalEdges, parsedCount, skippedCount int
+	var totalSymbolsAfter, totalFilesAfter int
 
 	if err := st.WithTx(ctx, func(tx store.Tx) error {
 		// 8a. Delete removed files.
@@ -295,19 +309,23 @@ func Index(ctx context.Context, st *store.Store, repoRoot string, opts IndexOpti
 			SymbolCount: n,
 			FileCount:   len(files),
 		}
+		totalSymbolsAfter = n
+		totalFilesAfter = len(files)
 		return tx.WriteMeta(meta)
 	}); err != nil {
 		return Summary{}, fmt.Errorf("pipeline.Index: transaction: %w", err)
 	}
 
 	return Summary{
-		Parsed:    parsedCount,
-		Skipped:   skippedCount,
-		Removed:   len(removed),
-		Symbols:   totalSymbols,
-		Edges:     totalEdges,
-		Duration:  time.Since(start),
-		IndexedAt: now,
+		Parsed:       parsedCount,
+		Skipped:      skippedCount,
+		Removed:      len(removed),
+		Symbols:      totalSymbols,
+		Edges:        totalEdges,
+		TotalSymbols: totalSymbolsAfter,
+		TotalFiles:   totalFilesAfter,
+		Duration:     time.Since(start),
+		IndexedAt:    now,
 	}, nil
 }
 

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -72,6 +72,14 @@ func TestIndex_FreshRepo(t *testing.T) {
 	if sum.IndexedAt.IsZero() {
 		t.Error("IndexedAt zero")
 	}
+	// Issue #1: TotalSymbols / TotalFiles must reflect the cumulative state
+	// written to meta (so registry mirror and `status` agree).
+	if sum.TotalFiles != 2 {
+		t.Errorf("TotalFiles = %d; want 2", sum.TotalFiles)
+	}
+	if sum.TotalSymbols != sum.Symbols {
+		t.Errorf("on a fresh repo TotalSymbols (%d) must equal Symbols (%d)", sum.TotalSymbols, sum.Symbols)
+	}
 }
 
 func TestIndex_IncrementalSkipsUnchanged(t *testing.T) {
@@ -96,6 +104,15 @@ func TestIndex_IncrementalSkipsUnchanged(t *testing.T) {
 	}
 	if sum.Parsed != 0 {
 		t.Errorf("expected 0 parsed on no-op run; got %d", sum.Parsed)
+	}
+	// Issue #1 regression: TotalFiles/TotalSymbols must reflect the
+	// cumulative index state, not just what was inserted in this run
+	// (which is 0 for a no-op). Symbols=0 but TotalSymbols must remain >0.
+	if sum.TotalFiles != 1 {
+		t.Errorf("TotalFiles after no-op run = %d; want 1 (cumulative)", sum.TotalFiles)
+	}
+	if sum.TotalSymbols == 0 {
+		t.Errorf("TotalSymbols after no-op run = 0; want the cumulative count")
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -300,6 +300,60 @@ func TestStore_SearchBM25_Basic(t *testing.T) {
 	}
 }
 
+// TestStore_SearchBM25_PrefixExpansion guards Issue #2: a query like "parse"
+// must match symbols whose tokens begin with "parse" (e.g. "parser",
+// "parsing"), since BM25 over IN(...) is exact-match and tokens aren't
+// stemmed at index time.
+func TestStore_SearchBM25_PrefixExpansion(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	err := st.WithTx(ctx, func(tx Tx) error {
+		if err := tx.UpsertFile(core.File{Path: "a.py", SHA1: "h", IndexedAt: now, Language: "python", SizeBytes: 1}); err != nil {
+			return err
+		}
+		ids, err := tx.InsertSymbols([]core.Symbol{
+			{Name: "parser", Qualname: "a.parser", Kind: core.SymbolFunction, Scope: core.ScopeGlobal, File: "a.py", LineStart: 1, LineEnd: 2, Snippet: "def parser"},
+			{Name: "unrelated", Qualname: "a.unrelated", Kind: core.SymbolFunction, Scope: core.ScopeGlobal, File: "a.py", LineStart: 3, LineEnd: 4, Snippet: "def unrelated"},
+		})
+		if err != nil {
+			return err
+		}
+		for i, s := range []core.Symbol{
+			{Name: "parser", Qualname: "a.parser"},
+			{Name: "unrelated", Qualname: "a.unrelated"},
+		} {
+			if err := tx.InsertTokens(ids[i], lexical.Tokenize(s)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Query "parse" must hit "parser" via prefix expansion.
+	err = st.WithTx(ctx, func(tx Tx) error {
+		results, err := tx.SearchBM25(ctx, "parse", 10, lexical.Filters{})
+		if err != nil {
+			return err
+		}
+		if len(results) == 0 {
+			t.Fatalf("query \"parse\" returned no results; expected to hit \"parser\" via prefix expansion")
+		}
+		hyd, _ := tx.HydrateSymbols([]int64{results[0].SymbolID})
+		if hyd[0].Name != "parser" {
+			t.Errorf("top hit = %q; want parser", hyd[0].Name)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestStore_SchemaMismatch(t *testing.T) {
 	root := t.TempDir()
 	st, err := Open(root)

--- a/internal/store/tx.go
+++ b/internal/store/tx.go
@@ -281,6 +281,60 @@ func (t *txImpl) SearchBM25(ctx context.Context, query string, topN int, f lexic
 		}
 	}
 
+	// Issue #2: token IN (...) is exact-match only, so a query for "parse"
+	// misses every "parser"/"parsed" symbol. Expand each query term of
+	// length >= prefixExpandMin with stored tokens that begin with it.
+	// SQLite uses the index on tokens(token) for `LIKE 'parse%'` because
+	// the column is text and the pattern has no leading wildcard.
+	//
+	// We cap the expansion per term so that a one-letter prefix can't
+	// pull in tens of thousands of tokens; that case stays exact-match.
+	const (
+		prefixExpandMin    = 3
+		prefixExpandPerTok = 64
+	)
+	if len(terms) > 0 {
+		expandedSet := make(map[string]struct{}, len(terms))
+		for _, qt := range terms {
+			expandedSet[qt] = struct{}{}
+		}
+		for _, qt := range terms {
+			if len([]rune(qt)) < prefixExpandMin {
+				continue
+			}
+			rows, err := t.tx.QueryContext(ctx,
+				"SELECT DISTINCT token FROM tokens WHERE token LIKE ? ESCAPE '\\' LIMIT ?",
+				escapeLike(qt)+"%", prefixExpandPerTok+1)
+			if err != nil {
+				return nil, fmt.Errorf("store.SearchBM25 expand %q: %w", qt, err)
+			}
+			count := 0
+			overflow := false
+			for rows.Next() {
+				var tok string
+				if err := rows.Scan(&tok); err != nil {
+					rows.Close()
+					return nil, fmt.Errorf("store.SearchBM25 expand scan: %w", err)
+				}
+				count++
+				if count > prefixExpandPerTok {
+					// Too many matches — skip expansion for this term;
+					// the original exact term stays in expandedSet.
+					overflow = true
+					break
+				}
+				expandedSet[tok] = struct{}{}
+			}
+			rows.Close()
+			_ = overflow
+		}
+		expanded := make([]string, 0, len(expandedSet))
+		for tok := range expandedSet {
+			expanded = append(expanded, tok)
+		}
+		terms = expanded
+	}
+
 	// Fetch corpus stats needed for BM25.
 	n, avgLen, err := t.Stats(ctx)
 	if err != nil {
@@ -897,6 +951,25 @@ func globToLike(glob string) string {
 			sb.WriteByte(c)
 		}
 		i++
+	}
+	return sb.String()
+}
+
+// escapeLike escapes the LIKE wildcards (`%`, `_`) and the escape char `\`
+// itself so a user-provided string can be safely used as the literal portion
+// of a `WHERE col LIKE 'literal%' ESCAPE '\'` query.
+func escapeLike(s string) string {
+	if !strings.ContainsAny(s, `%_\`) {
+		return s
+	}
+	var sb strings.Builder
+	sb.Grow(len(s) + 4)
+	for _, r := range s {
+		switch r {
+		case '%', '_', '\\':
+			sb.WriteByte('\\')
+		}
+		sb.WriteRune(r)
 	}
 	return sb.String()
 }


### PR DESCRIPTION
## Summary

Two independent fixes bundled because both are small and the test surface
is the same.

### Issue #1 — \`status\` and \`list\` disagree on counts
\`status\` reads cumulative counts from SQLite \`meta\`. \`list\` reads from
the registry, which was being populated with per-run delta values
(\`sum.Symbols\` = symbols inserted *this run*, \`sum.Parsed+Skipped\` =
files visited *this run*). After any incremental run the two views
disagreed.

Fix: \`Summary\` now exposes cumulative \`TotalSymbols\` / \`TotalFiles\`
captured inside the same transaction that writes \`meta\`. CLI mirrors
those into the registry. Fast-path (no changed files) reads existing
\`meta\` and forwards the same values so a no-op run doesn't zero the
registry.

### Issue #2 — \`parse\` returns 0 results, \`parser\` returns 26
The BM25 candidate query is exact-match over the \`tokens\` table.
\`parser\` is stored, \`parse\` is not, so a typed-prefix query misses
everything.

Fix: at query time, expand each query term of length ≥ 3 with all
stored tokens that begin with it (\`token LIKE 'parse%' ESCAPE '\'\`).
SQLite's index on \`tokens(token)\` handles the prefix scan. Per-term
cap of 64 expansions; overflow falls back to exact match for that
term so a 3-char query can't pull tens of thousands of rows.

Stemming was the textbook alternative but adds a dependency and
changes scoring semantics; this stays simpler.

## Test plan

- [x] \`go test ./internal/pipeline/...\` — TotalFiles/TotalSymbols
      reflect cumulative state on both first run and no-op run.
- [x] \`go test ./internal/store/...\` — \`TestStore_SearchBM25_PrefixExpansion\`
      verifies \`parse\` query hits \`parser\` symbol.
- [x] CGO-free packages all green locally; tree-sitter packages need
      CI to build (no local gcc).