### PR TITLE
docs: refresh README — install-self, design philosophy, accurate status

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -27,11 +27,12 @@ agent  →  1,800 줄 통째로 읽지 않고 36 줄만 읽음
 ## 핵심 특징
 
 - **per-repo SQLite 인덱스** (`<repo>/.codemap/index.db`) + **글로벌 레지스트리**
-  (`~/.codemap/registry.toml`). 서버도, 데몬도 없습니다.
-- **BM25 lexical 검색** 이 기본. ML 의존성 0, 식별자 형태의 질의에 빠릅니다 —
-  실제 워크로드의 대부분이 이쪽입니다.
-- **선택적 encoder rerank** 는 빌드 태그 (`-tags encoder`) 뒤에 격리되어 있습니다.
-  기본 빌드는 가볍고 콜드 스타트가 빠릅니다.
+  (`~/.codemap/registry.toml`). 서버도, 데몬도, 백그라운드 프로세스도
+  없습니다 — 매 호출마다 새 프로세스이고 콜드 스타트 예산은 50 ms 이하입니다.
+- **BM25 lexical 검색** 이 기본 — 직접 구현, ML 의존성 0, 식별자 형태의
+  질의에 빠릅니다 (실제 워크로드의 대부분이 이쪽입니다). 선택적 encoder
+  rerank 는 `-tags encoder` 뒤에 격리되어 있어 기본 바이너리는 가볍게
+  유지됩니다.
 - **Tree-sitter 파서** 가 함수 / 메서드 / 클래스 / 변수 / 임포트 / 상수와
   call / reference / inherit / import 엣지를 추출합니다. 지원 언어:
   Python, Java, JavaScript, TypeScript, TSX, C#, C++. Go / Rust 는 스캐폴딩만
@@ -39,18 +40,54 @@ agent  →  1,800 줄 통째로 읽지 않고 36 줄만 읽음
 - **SKILL.md 자동 설치** — `codemap install-skill` 로 Claude Code (그리고
   스펙이 확정되면 Codex) 가 파일 통째 읽기 전에 codemap 을 먼저 호출하도록
   설치합니다.
-- **단일 정적 바이너리** — zig-cc 로 크로스 컴파일하여 Homebrew, GitHub
-  Releases, `go install` 로 배포.
+- **원샷 셀프 인스톨** — `codemap install-self` 가 바이너리를
+  `~/.codemap/bin` 에 복사하고 사용자 PATH 에 영구 등록합니다 (Windows 는
+  HKCU, Unix 는 셸 rc 파일). 관리자 권한 필요 없습니다.
+- **단일 정적 바이너리** — 릴리스 아티팩트는 zig-cc 로 크로스 컴파일되어
+  나오므로, tree-sitter 가 내부적으로 CGO 를 쓰는데도 사용자 머신에 C
+  툴체인이 필요하지 않습니다.
 - **로컬 only.** 기본 빌드는 외부 네트워크 호출이 0건. 인덱스는 머신 밖으로
   나가지 않습니다.
 
+## 개발 철학
+
+codemap 은 무엇인가, 그리고 무엇이 아닌가에 대해 의견이 분명합니다. 같은
+트레이드오프가 어떤 워크플로우에는 잘 맞고 어떤 워크플로우에는 잘 안
+맞기 때문에, 경계를 먼저 명시합니다.
+
+- **에이전트 우선, 사람 우선이 아님.** 주 사용자는 매 턴마다 codemap 을
+  서브프로세스로 호출하는 코딩 에이전트이지, IDE 에서 그래프를 탐색하는
+  사람이 아닙니다. CLI 와 안정적인 JSON 계약이 먼저, GUI 는 나중. 인터랙티브
+  `graph.html` 은 데이터를 갖고 있는 김에 만든 부산물이지 메인 제품이
+  아닙니다.
+- **순수 retrieval, LLM 없음.** codemap 은 식별자와 `file:line` 범위를
+  돌려줍니다. LLM 을 내장하지 않고, 외부 임베딩 API 도 호출하지 않으며,
+  RAG 식 chunking 도, 자연어 해석도 하지 않습니다. 모든 추론은 호출자의
+  책임. 비용이 예측 가능하고, 출력이 검증 가능하며, 바이너리가 단순하게
+  배포됩니다.
+- **재사용 비용 절감 우선, 정확도 깊이는 양보.** 인덱싱은 인크리멘털
+  (per-file SHA-1), 변경 없는 재호출은 약 10 ms, `status` 는 SQLite meta
+  헤더만 읽습니다. 에이전트가 비용 걱정 없이 매 턴마다 호출할 수
+  있습니다. 그 대신 codemap 은 의도적으로 tree-sitter 선에서 멈춥니다 —
+  타입 인식 리졸버를 돌리거나 완전한 콜그래프를 빌드하거나, 모든 엣지가
+  알려진 심볼로 resolve 된다고 보장하지 않습니다. 그게 필요하면 IDE 나
+  language server 를 쓰세요. codemap 은 그것들을 대체하려는 도구가
+  아닙니다.
+- **지루하고 의존성 적은 기술.** SQLite (`modernc.org/sqlite`, pure
+  Go), BM25 직접 구현, ML 의존성은 빌드 태그 뒤에 격리, 플러그인 로더
+  없음. 언어 추가는 코드 수정 + 재빌드 입니다.
+- **로컬, 단일 사용자, 텔레메트리 없음.** 서버도, 공유 캐시도, 어떤 기본
+  코드 경로에서도 머신을 떠나는 데이터가 없습니다.
+
 ## 진행 상태
 
-M1 – M6 완료. Python + 6 개 언어 파서 (Java, JavaScript, TypeScript, TSX,
-C#, C++), `visualize` 와 모든 출력에 `lastIndexed` 노출, SKILL.md 설치기,
-`encoder` 빌드 태그 뒤의 인코더 rerank (ONNX 결선은 한 파일 교체로 가능),
-zig-cc + GoReleaser 기반 릴리스 파이프라인 (darwin amd64 / arm64,
-linux amd64 / arm64, windows amd64).
+Python + 6 개 언어 파서 (Java, JavaScript, TypeScript, TSX, C#, C++),
+`visualize` 와 모든 출력에 `lastIndexed` 노출, SKILL.md 설치기,
+원샷 PATH 설정용 `install-self`, `encoder` 빌드 태그 뒤의 인코더 rerank
+(ONNX 결선은 한 파일 교체로 가능), zig-cc + GoReleaser 기반 릴리스
+파이프라인. linux amd64 / arm64 와 windows amd64 바이너리가 모든
+`v*` 태그 푸시마다 게시됩니다. macOS 빌드는 일시 중단 (`.goreleaser.yml`
+참고).
 
 ## 빌드
 
@@ -73,6 +110,31 @@ make build   # ./bin/codemap 생성
 make vet     # go vet ./...
 make ci      # vet + build + encoder 빌드
 ```
+
+## 설치
+
+[Releases 페이지](https://github.com/devchan97/code-map/releases)
+에서 OS 에 맞는 아카이브를 받아 압축을 풀고, 한 번만 `install-self`
+를 실행합니다.
+
+```sh
+# Linux / macOS
+./codemap install-self
+
+# Windows (PowerShell, 압축을 푼 폴더에서)
+.\codemap.exe install-self
+```
+
+바이너리가 `~/.codemap/bin` 에 복사되고 사용자 PATH 에 등록됩니다
+(Windows 는 HKCU\Environment, Unix 는 `~/.bashrc` /
+`~/.zshrc` / `~/.config/fish/config.fish` / `~/.profile` 의 마커
+블록). 새 셸을 열면 어디서든 `codemap` 으로 호출됩니다. 되돌리려면
+`codemap uninstall-self` 를 실행하세요.
+
+Go 툴체인과 C 컴파일러가 이미 있으면
+`go install github.com/devchan97/code-map/cmd/codemap@latest` 도
+가능합니다 — `$GOPATH/bin` 에 설치되며, 보통 이미 PATH 에 잡혀
+있습니다.
 
 ## 빠른 시작
 
@@ -124,6 +186,8 @@ codemap install-skill --agent claude-code --scope user
 | `codemap visualize [PATH\|NAME] [flags]` | `graph.html` 렌더. 플래그: `--out`, `--open`. |
 | `codemap install-skill` | SKILL.md 설치. 플래그: `--agent`, `--scope`, `--print`. |
 | `codemap uninstall-skill` | 설치된 SKILL.md 제거. |
+| `codemap install-self` | 실행 중인 바이너리를 `~/.codemap/bin` 에 복사하고 사용자 PATH 에 등록. |
+| `codemap uninstall-self` | 설치된 바이너리 제거 + PATH 변경 되돌리기. |
 | `codemap version` | 버전, 스키마 버전, 활성 embedder 출력. |
 
 ## 아키텍처
@@ -227,12 +291,13 @@ tree-sitter 는 CGO 가 필요하기 때문에 Python 파서 테스트는 `//go:
 CGO 없는 개발 환경에서도 그 외 모든 코드와 테스트는 정상적으로 빌드/통과합니다.
 
 릴리스는 `.github/workflows/release.yml` 이 담당합니다. `ubuntu-latest`
-단일 러너에서 GoReleaser 를 돌리고, 모든 CGO 타깃 (darwin amd64 / arm64,
-linux amd64 / arm64, windows amd64) 은 zig-cc 를 범용 크로스 컴파일러로
-사용합니다. 각 타깃별 `-target <triple>` 플래그는 `scripts/` 의 한 줄짜리
-wrapper 스크립트에 박혀 있어, `$CC` / `$CXX` 를 단일 실행파일 경로로
-유지합니다 — wrapper 없이 `CC=zig cc -target …` 처럼 공백을 포함하면 Go 링커
-단계가 깨집니다. `v*` 태그 푸시마다 트리거됩니다. windows arm64 는 후순위입니다.
+단일 러너에서 GoReleaser 를 돌리고, 모든 CGO 타깃은 zig-cc 를 범용 크로스
+컴파일러로 사용합니다. 각 타깃별 `-target <triple>` 플래그는 `scripts/`
+의 한 줄짜리 wrapper 스크립트에 박혀 있어, `$CC` / `$CXX` 를 단일 실행파일
+경로로 유지합니다 — wrapper 없이 `CC=zig cc -target …` 처럼 공백을 포함하면
+Go 링커 단계가 깨집니다. `v*` 태그 푸시마다 트리거됩니다. 현재는 linux
+amd64 / arm64 와 windows amd64 가 게시되며, darwin 과 windows arm64 는
+후순위입니다.
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ agent can partial-read instead of loading entire files.
 ## Highlights
 
 - **Embedded per-repo SQLite store** at `<repo>/.codemap/index.db` plus a
-  global registry at `~/.codemap/registry.toml`. No server, no daemon.
-- **Lexical retrieval (BM25)** by default — zero ML dependency, fast on
-  identifier-shaped queries (the dominant workload).
-- **Optional encoder rerank** behind a build tag (`-tags encoder`) for
-  prose-heavy queries. Off by default to keep the binary small and cold-start
-  fast.
+  global registry at `~/.codemap/registry.toml`. No server, no daemon, no
+  background process — every invocation is a fresh process with a cold-start
+  budget under 50 ms.
+- **Lexical retrieval (BM25)**, hand-rolled, by default. Zero ML
+  dependency, fast on identifier-shaped queries (the dominant workload).
+  Optional encoder rerank lives behind `-tags encoder` so the default
+  binary stays small.
 - **Tree-sitter parsers** for Python, Java, JavaScript, TypeScript, TSX,
   C#, and C++. Extract symbols (functions, methods, classes, variables,
   imports, constants) plus call / reference / inherit / import edges. Go and
@@ -40,19 +41,55 @@ agent can partial-read instead of loading entire files.
 - **SKILL.md auto-install** via `codemap install-skill` so coding agents
   (Claude Code; Codex when its skill spec is final) call codemap before
   reading whole files.
-- **Single static binary**, cross-compiled with zig-cc and distributed via
-  Homebrew, GitHub Releases, and `go install`.
-- **Local only.** Default builds make zero outbound network calls; the index
-  never leaves your machine.
+- **One-shot install** via `codemap install-self` — copies the binary to
+  `~/.codemap/bin` and persists it on `PATH` (HKCU on Windows, shell rc on
+  Unix). No admin rights required.
+- **Single static binary** for end users — release artifacts are
+  cross-compiled with zig-cc, so installing codemap does not require a
+  local C toolchain even though tree-sitter is CGO under the hood.
+- **Local only.** Default builds make zero outbound network calls; the
+  index never leaves your machine.
+
+## Design philosophy
+
+codemap is opinionated about what it is and what it is not. The same
+trade-offs that make it a good fit for one workflow make it a poor fit
+for another, so the boundaries are stated up front.
+
+- **Agent-first, not human-first.** The primary user is a coding agent
+  calling codemap as a subprocess on every relevant turn, not a human
+  navigating a graph in an IDE. CLI + stable JSON contracts come first;
+  GUIs come last. The interactive `graph.html` is a useful side effect of
+  having the data, not the product.
+- **Pure retrieval, no LLM.** codemap returns identifiers and `file:line`
+  ranges. It does not embed an LLM, call an external embedding API, do
+  RAG-style chunking, or interpret natural language. All reasoning is the
+  caller's responsibility. This keeps cost predictable, output auditable,
+  and the binary trivial to ship.
+- **Cheap reuse over deep accuracy.** Indexing is incremental
+  (per-file SHA-1), no-op runs finish in around 10 ms, and `status` reads
+  only the SQLite meta header. An agent can call codemap on every turn
+  without thinking about cost. The trade-off is that codemap deliberately
+  stops at tree-sitter — it does not run a type-aware resolver, build a
+  full call graph, or guarantee every edge resolves to a known symbol.
+  When you need that, reach for an IDE or a language server; codemap is
+  not trying to replace them.
+- **Boring, dependency-light tech.** SQLite (`modernc.org/sqlite`, pure
+  Go), BM25 hand-rolled instead of pulling in a search engine, ML
+  dependencies gated behind a build tag, no plugin loader. Adding a
+  language is a code change and a rebuild.
+- **Local, single-user, no telemetry.** No server, no shared cache, no
+  data leaving the machine in any default code path.
 
 ## Status
 
-M1 – M6 complete. Python + 6 additional language parsers (Java, JavaScript,
-TypeScript, TSX, C#, C++), `visualize` with `lastIndexed` surfaced
-everywhere, SKILL.md installer, encoder rerank gated behind the `encoder`
-build tag (ONNX wiring is a one-file swap), and a zig-cc + GoReleaser
-release pipeline targeting darwin amd64 / arm64, linux amd64 / arm64, and
-windows amd64.
+Python + six additional language parsers (Java, JavaScript, TypeScript,
+TSX, C#, C++), `visualize` with `lastIndexed` surfaced everywhere,
+SKILL.md installer, `install-self` for one-shot PATH setup, encoder
+rerank gated behind the `encoder` build tag (ONNX wiring is a one-file
+swap), and a zig-cc + GoReleaser release pipeline. Linux amd64 / arm64
+and Windows amd64 binaries are published on every `v*` tag; macOS
+builds are temporarily disabled (see `.goreleaser.yml`).
 
 ## Build
 
@@ -75,6 +112,31 @@ make build   # builds ./bin/codemap
 make vet     # go vet ./...
 make ci      # vet + build + encoder-tag build
 ```
+
+## Install
+
+Download the appropriate archive from the
+[Releases page](https://github.com/devchan97/code-map/releases),
+extract it, and run the binary once with `install-self`:
+
+```sh
+# Linux / macOS
+./codemap install-self
+
+# Windows (PowerShell, from the extracted folder)
+.\codemap.exe install-self
+```
+
+This copies the binary to `~/.codemap/bin` and registers that path on
+your user `PATH` (HKCU\Environment on Windows, a marker block in
+`~/.bashrc` / `~/.zshrc` / `~/.config/fish/config.fish` / `~/.profile`
+on Unix). Open a new shell afterwards and `codemap` works as a bare
+command. `codemap uninstall-self` reverses both side effects.
+
+If you already have a Go toolchain and the relevant C compiler,
+`go install github.com/devchan97/code-map/cmd/codemap@latest` is also
+an option — it lands the binary in `$GOPATH/bin`, which most people
+already have on `PATH`.
 
 ## Quick start
 
@@ -126,6 +188,8 @@ the public contract — see `architecture.md` §6.2.
 | `codemap visualize [PATH\|NAME] [flags]` | Render `graph.html`. Flags: `--out`, `--open`. |
 | `codemap install-skill` | Install SKILL.md. Flags: `--agent`, `--scope`, `--print`. |
 | `codemap uninstall-skill` | Remove the installed SKILL.md. |
+| `codemap install-self` | Copy the running binary to `~/.codemap/bin` and add it to user PATH. |
+| `codemap uninstall-self` | Remove the installed binary and undo the PATH change. |
 | `codemap version` | Print version, schema version, and active embedder. |
 
 ## Architecture
@@ -233,12 +297,12 @@ the rest of the codebase still builds and tests cleanly.
 
 Releases are produced by `.github/workflows/release.yml`, which runs
 GoReleaser on a single `ubuntu-latest` runner and uses zig-cc as a universal
-cross-compiler for every CGO target (darwin amd64 / arm64, linux amd64 /
-arm64, windows amd64). One-line wrapper scripts in `scripts/` bake each
-target's `-target <triple>` flag into `$CC` / `$CXX` so CGO sees a single
-executable path — without that wrapper indirection, spaces in `CC=zig cc
--target …` break Go's link step. Triggered by every `v*` tag push. Windows
-arm64 is deferred.
+cross-compiler for every CGO target. One-line wrapper scripts in `scripts/`
+bake each target's `-target <triple>` flag into `$CC` / `$CXX` so CGO sees
+a single executable path — without that wrapper indirection, spaces in
+`CC=zig cc -target …` break Go's link step. Triggered by every `v*` tag
+push. Linux amd64 / arm64 and Windows amd64 are currently shipped; darwin
+and Windows arm64 are deferred.
 
 ## License
 


### PR DESCRIPTION
## Summary

The README had drifted from reality after the recent PRs. Three things
to fix:

1. **install-self / uninstall-self** weren't listed anywhere — added a
   dedicated \"Install\" section with platform-specific commands and
   added both subcommands to the CLI reference table.
2. **Status and release sections** still advertised darwin builds and
   Homebrew distribution; both were dropped by #4 while we look for a
   stable macOS cross-build path. Updated to reflect what the release
   pipeline actually publishes (linux amd64 / arm64 + windows amd64).
3. **No statement of why the project stops where it stops.** The
   Highlights bullets describe *what* codemap does, but a reader can't
   tell from the README whether codemap is meant to compete with an
   IDE / language server or stay deliberately shallower than that.
   Added a \"Design philosophy\" section that names the five
   trade-offs explicitly: agent-first not human-first, pure retrieval
   with no LLM, cheap reuse over deep accuracy, dependency-light tech,
   and local-only with no telemetry. Same wording in EN and KR.

## Test plan

- [x] EN/KR diffs are mirror images of each other (sections, ordering,
      bullet count match).
- [x] All commands referenced (\`install-self\`, \`uninstall-self\`,
      etc.) exist on \`main\` post-PR-#6.
- [x] Status section claims match \`.goreleaser.yml\` and the v0.1.2
      release artifact list.
- [ ] Reviewer eye-check that the philosophy bullets read as
      trade-offs (\"we do X, we don't do Y\") and not as marketing.