### PR TITLE
Add indexer_ver to flag stale data after parser/tokenizer changes

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -22,7 +22,13 @@ type statusOutput struct {
 	SymbolCount int       `json:"symbol_count"`
 	Embedder    string    `json:"embedder"`
 	SchemaVer   int       `json:"schema_ver"`
-	Stale       bool      `json:"stale"`
+	IndexerVer  int       `json:"indexer_ver"`
+	// Stale is true when the index data was produced by a different
+	// IndexerVer than the running binary. The DB still reads, but
+	// search results may not reflect the current parser/tokenizer
+	// rules; user should run `codemap reindex`.
+	Stale       bool   `json:"stale"`
+	StaleReason string `json:"stale_reason,omitempty"`
 }
 
 // readMeta reads the meta table from st inside a short read-only transaction.
@@ -72,6 +78,28 @@ func newStatusCmd() *cobra.Command {
 				return fmt.Errorf("status: %w", err)
 			}
 
+			// Surface indexer_ver skew as a stale flag rather than a
+			// hard error: the data is still readable, just produced by
+			// an older parser/tokenizer that may emit different
+			// qualnames or tokens than the running binary.
+			stale := false
+			reason := ""
+			if meta.IndexerVer != 0 && meta.IndexerVer != store.IndexerVer {
+				stale = true
+				reason = fmt.Sprintf(
+					"indexer_ver %d on disk, %d in this binary — run `codemap reindex` to refresh",
+					meta.IndexerVer, store.IndexerVer,
+				)
+			} else if meta.IndexerVer == 0 {
+				// Pre-IndexerVer index. Treat as stale once the binary
+				// understands the field; user reindex is cheap.
+				stale = true
+				reason = fmt.Sprintf(
+					"index predates indexer_ver tracking — run `codemap reindex` to upgrade to indexer_ver %d",
+					store.IndexerVer,
+				)
+			}
+
 			out := statusOutput{
 				Name:        entry.Name,
 				Path:        entry.Path,
@@ -80,7 +108,9 @@ func newStatusCmd() *cobra.Command {
 				SymbolCount: meta.SymbolCount,
 				Embedder:    meta.Embedder,
 				SchemaVer:   meta.SchemaVer,
-				Stale:       false, // v1: always false
+				IndexerVer:  meta.IndexerVer,
+				Stale:       stale,
+				StaleReason: reason,
 			}
 
 			if jsonOut {
@@ -96,7 +126,11 @@ func newStatusCmd() *cobra.Command {
 			fmt.Printf("symbol_count: %d\n", out.SymbolCount)
 			fmt.Printf("embedder:     %s\n", out.Embedder)
 			fmt.Printf("schema_ver:   %d\n", out.SchemaVer)
+			fmt.Printf("indexer_ver:  %d\n", out.IndexerVer)
 			fmt.Printf("stale:        %v\n", out.Stale)
+			if out.StaleReason != "" {
+				fmt.Printf("              %s\n", out.StaleReason)
+			}
 			return nil
 		},
 	}

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -59,7 +59,16 @@ type Edge struct {
 // Meta holds the top-level metadata for a repo index.
 type Meta struct {
 	// SchemaVer is the integer schema version stored in the index.
+	// Bumped when the on-disk SQLite layout changes; mismatch is a hard
+	// error (the DB literally can't be read by a newer/older binary).
 	SchemaVer int `json:"schema_ver"`
+	// IndexerVer is bumped when the meaning of the data changes — a
+	// new tokenizer rule, a parser that emits qualnames differently,
+	// etc. The DB is still readable across an indexer_ver skew, but
+	// search results will be wrong until the user runs `codemap
+	// reindex`. Surfaced via `codemap status` rather than failing
+	// open(); see internal/store/schema.go for the current value.
+	IndexerVer int `json:"indexer_ver"`
 	// RepoRoot is the absolute path to the indexed repository root.
 	RepoRoot string `json:"repo_root"`
 	// IndexedAt is the UTC timestamp of the most recent successful index run.

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -111,7 +111,11 @@ func Index(ctx context.Context, st *store.Store, repoRoot string, opts IndexOpti
 	if len(changed) == 0 && len(removed) == 0 && !opts.Force {
 		now := time.Now().UTC()
 		var fastSymbols, fastFiles int
-		// Still write updated indexed_at.
+		// Still write updated indexed_at. We deliberately do NOT bump
+		// indexer_ver in the fast path: a no-op walk is exactly the case
+		// where data may be stale relative to the running binary, and
+		// the user wants `status` to keep flagging it until they
+		// explicitly reindex.
 		if err := st.WithTx(ctx, func(tx store.Tx) error {
 			meta, err := tx.ReadMeta()
 			if err != nil {
@@ -303,6 +307,7 @@ func Index(ctx context.Context, st *store.Store, repoRoot string, opts IndexOpti
 
 		meta := core.Meta{
 			SchemaVer:   store.SchemaVer,
+			IndexerVer:  store.IndexerVer,
 			RepoRoot:    repoRoot,
 			IndexedAt:   now,
 			Embedder:    embedder,

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -2,7 +2,21 @@
 package store
 
 // SchemaVer is the current on-disk schema version.
+//
+// Bump when the SQLite layout changes — i.e. when an older binary could
+// no longer correctly read the new DB or vice versa. Mismatch is a hard
+// error caught at Open() time; the user must `codemap reindex`.
 const SchemaVer = 1
+
+// IndexerVer is the current parser/tokenizer/edge-format version.
+//
+// Bump when the *meaning* of stored data changes even though the SQLite
+// layout did not — e.g. tokenizer rule change, parser emitting qualnames
+// differently, edge resolver behaviour change. The DB is still readable
+// across a skew, but search results will be stale; the mismatch is
+// surfaced via `codemap status` (Stale=true) rather than failing
+// Open(), so existing scripts keep working until the user reindexes.
+const IndexerVer = 1
 
 // schemaSQL is the DDL applied to a fresh database.
 // Statements are separated by semicolons and applied via a single db.Exec call.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -300,6 +300,38 @@ func TestStore_SearchBM25_Basic(t *testing.T) {
 	}
 }
 
+// TestStore_Meta_RoundTripsIndexerVer guards that a write/read cycle on the
+// meta table preserves both schema_ver and indexer_ver. Without this, a
+// silently-dropped indexer_ver would defeat the staleness warning that
+// `status` relies on after a parser/tokenizer change.
+func TestStore_Meta_RoundTripsIndexerVer(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	want := core.Meta{
+		SchemaVer: SchemaVer, IndexerVer: IndexerVer,
+		RepoRoot: "/r", IndexedAt: now, Embedder: "lexical",
+		FileCount: 3, SymbolCount: 9,
+	}
+	if err := st.WithTx(ctx, func(tx Tx) error { return tx.WriteMeta(want) }); err != nil {
+		t.Fatal(err)
+	}
+	var got core.Meta
+	if err := st.WithTx(ctx, func(tx Tx) error {
+		var err error
+		got, err = tx.ReadMeta()
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got.IndexerVer != want.IndexerVer {
+		t.Errorf("IndexerVer round-trip = %d; want %d", got.IndexerVer, want.IndexerVer)
+	}
+	if got.SchemaVer != want.SchemaVer {
+		t.Errorf("SchemaVer round-trip = %d; want %d", got.SchemaVer, want.SchemaVer)
+	}
+}
+
 // TestStore_SearchBM25_PrefixExpansion guards Issue #2: a query like "parse"
 // must match symbols whose tokens begin with "parse" (e.g. "parser",
 // "parsing"), since BM25 over IN(...) is exact-match and tokens aren't

--- a/internal/store/tx.go
+++ b/internal/store/tx.go
@@ -542,6 +542,9 @@ func (t *txImpl) ReadMeta() (core.Meta, error) {
 	if v, ok := kv["schema_ver"]; ok {
 		m.SchemaVer, _ = strconv.Atoi(v)
 	}
+	if v, ok := kv["indexer_ver"]; ok {
+		m.IndexerVer, _ = strconv.Atoi(v)
+	}
 	m.RepoRoot = kv["repo_root"]
 	m.Embedder = kv["embedder"]
 	if v, ok := kv["indexed_at"]; ok {
@@ -562,6 +565,7 @@ func (t *txImpl) WriteMeta(m core.Meta) error {
 	type kv struct{ k, v string }
 	pairs := []kv{
 		{"schema_ver", strconv.Itoa(m.SchemaVer)},
+		{"indexer_ver", strconv.Itoa(m.IndexerVer)},
 		{"repo_root", m.RepoRoot},
 		{"indexed_at", m.IndexedAt.UTC().Format(time.RFC3339)},
 		{"embedder", m.Embedder},


### PR DESCRIPTION
## Summary

\`schema_ver\` caught DB-layout skew but stayed silent about parser /
tokenizer changes that the same SQLite layout could host. After PR #5
landed (BM25 prefix expansion at query time, no schema change), this
gap was visible: a user upgrading codemap could keep search results
that reflect the *old* parser's qualnames forever, with nothing
nudging them to reindex.

This PR adds a sibling concept, \`indexer_ver\`, with different policy
from schema_ver:

- **schema_ver mismatch** stays a hard error at \`Open()\` — the DB
  literally can't be read.
- **indexer_ver mismatch** is a soft warning surfaced through
  \`codemap status\` (\`Stale=true\` plus a one-line reason). \`Open()\`
  succeeds, existing scripts keep working, and the user gets an
  explicit prompt to run \`codemap reindex\`.

\`pipeline.Index\` writes the running binary's IndexerVer in the main
transaction. The no-op fast path deliberately leaves the on-disk value
alone — that's exactly the case where stale data is most likely, so
\`status\` should keep flagging it until the user reindexes.

Pre-IndexerVer indexes (value 0 / missing) are also reported stale so
existing users get a one-time prompt rather than silent inconsistency.

## What \`status\` shows

\`\`\`
$ codemap status
...
schema_ver:   1
indexer_ver:  1
stale:        false
\`\`\`

After a hypothetical bump to \`IndexerVer = 2\` in the binary,
indexes built by an older codemap show:

\`\`\`
$ codemap status
...
indexer_ver:  1
stale:        true
              indexer_ver 1 on disk, 2 in this binary — run \`codemap reindex\` to refresh
\`\`\`

## Test plan

- [x] \`go test ./internal/store/...\` — round-trip test
      \`TestStore_Meta_RoundTripsIndexerVer\` covers WriteMeta/ReadMeta.
- [x] \`go test ./internal/pipeline/...\` and \`./internal/cli/...\` clean.
- [ ] CI on Linux/macOS/Windows. (Tree-sitter CGO packages are
      unaffected, but a green matrix is reassuring.)