### PR TITLE
fix(cli): one-line message for install-skill --agent codex

### DIFF
--- a/internal/cli/skill.go
+++ b/internal/cli/skill.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -43,6 +44,15 @@ target agent. Use --scope project to place it inside the current repo.`,
 
 			result, err := skill.Install(t, printOnly)
 			if err != nil {
+				// codex spec is still upstream-pending; turn the long
+				// wrap chain (`install-skill: skill: install: skill:
+				// resolve path: ...`) into a single user-readable line.
+				if errors.Is(err, skill.ErrCodexPending) {
+					return fmt.Errorf(
+						"agent %q is not yet supported (codex skill spec is still being finalised upstream).\n"+
+							"Use --print to dump the SKILL.md body and place it manually, or use --agent claude-code",
+						agent)
+				}
 				return fmt.Errorf("install-skill: %w", err)
 			}
 

--- a/internal/skill/paths.go
+++ b/internal/skill/paths.go
@@ -18,8 +18,15 @@ type Target struct {
 	Version    string // version string substituted into the template
 }
 
-// errCodexPending is the sentinel used when a codex target is requested.
-var errCodexPending = errors.New("codex skill spec pending; verify at release time")
+// ErrCodexPending is returned when a codex target is requested while the
+// upstream Codex skill spec is still being finalised. Exported so the CLI
+// layer can detect the case via errors.Is and replace the long wrap chain
+// with a single user-readable message.
+var ErrCodexPending = errors.New("codex skill spec pending; verify at release time")
+
+// errCodexPending keeps the previous unexported alias for tests in this
+// package; new code should use ErrCodexPending.
+var errCodexPending = ErrCodexPending
 
 // ResolvePath returns the absolute file path for the SKILL.md of the given target.
 // Output paths are normalized to forward slashes.


### PR DESCRIPTION
## Summary

\`codemap install-skill --agent codex\` returned the right exit code
but with a 4-layer wrap chain that exposed package boundaries:

\`\`\`
Error: install-skill: skill: install: skill: resolve path: codex skill spec pending; verify at release time
\`\`\`

Promote \`errCodexPending\` to \`skill.ErrCodexPending\` so the CLI can
detect it via \`errors.Is\` and print a single user-facing sentence with
a concrete next step:

\`\`\`
Error: agent \"codex\" is not yet supported (codex skill spec is still
being finalised upstream). Use --print to dump the SKILL.md body and
place it manually, or use --agent claude-code
\`\`\`

The internal alias \`errCodexPending\` is preserved so the package's
existing tests keep passing without churn.

\`--print\` mode keeps working as before — it doesn't go through
ResolvePath, so users who want to drop the rendered template
somewhere by hand are unaffected.

## Test plan

- [x] \`go test ./internal/skill/... ./internal/cli/...\` clean.
- [x] Manual: \`codemap install-skill --agent codex\` shows the new
      single-line message; \`--print\` still emits the rendered body.
- [ ] CI on Linux/macOS/Windows.