### PR TITLE
docs: close §15 open questions that v0.1.x resolved

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -274,6 +274,9 @@ scripts/                     # zig-cc wrapper (릴리스 타깃별)
 - **Secret 회피 walker.** 흔한 시크릿 패턴 (`.env`, `*.pem`, `*.key`,
   `id_rsa*`, `id_ed25519*`, ...) 에 매칭되는 파일은 본문 읽기 전에 스킵됩니다.
   내용 스캔에서 AWS 액세스 키 prefix 나 PEM 헤더가 있으면 거부됩니다.
+  추가 경로를 제외하거나 프로젝트별로 기본값을 덮어쓰려면 레포 루트에
+  `.codemapignore` 파일 (gitignore 문법) 을 두세요. `.gitignore` 와 함께
+  매 walk 마다 적용됩니다.
 - **텔레메트리 없음.** codemap 은 외부로 데이터를 보내지 않습니다.
 
 ## 개발

--- a/README.md
+++ b/README.md
@@ -278,7 +278,9 @@ scripts/                     # zig-cc wrapper scripts (one per release target)
 - **Secrets-aware walker.** Files matching common secret patterns
   (`.env`, `*.pem`, `*.key`, `id_rsa*`, `id_ed25519*`, ...) are skipped before
   reading. Content scanning rejects files containing AWS access-key prefixes
-  or PEM headers.
+  or PEM headers. To exclude additional paths or to override the defaults
+  for a project, drop a `.codemapignore` file at the repo root (gitignore
+  syntax). It is honored alongside `.gitignore` on every walk.
 - **No telemetry.** codemap does not phone home.
 
 ## Development

--- a/codemap-design.md
+++ b/codemap-design.md
@@ -593,24 +593,61 @@ User runtime layout:
 
 ---
 
-## 15. Open Questions (non-blocking)
+## 15. Open Questions
 
-1. tree-sitter via CGO vs. WASM (purego). CGO simpler at runtime; WASM
-   avoids cross-build pain. Default to CGO for v1.
-2. BM25 implementation: Bleve vs. hand-rolled FTS over SQLite.
-   Hand-rolled is preferred for binary size and weighting control;
-   confirm during M1.
-3. Edge resolution depth for dynamic languages (Python duck typing,
-   JS/TS structural).
-4. Visualization library at scale: vis-network vs. cytoscape.js at 10k+
-   nodes; may need clustering or progressive disclosure.
-5. SKILL spec drift: confirm exact paths and frontmatter for both Claude
-   Code and Codex at release time.
-6. Secrets policy: auto-skip `.env`, `*.pem`, `*.key`, files matching
-   common secret patterns; document overrides.
-7. Monorepo: index per repo root, per workspace, or per declared
-   subproject. Default = per repo root for v1.
-8. Cross-repo search (`--repo a,b,c`) — defer to post-v1.
+Status as of v0.1.x. Resolved items moved to §16; remaining items are
+either deferred (cost outweighs current value) or blocked on upstream
+work outside this repo.
+
+### Resolved (see §16 for the final decision)
+
+- **Q1 — tree-sitter via CGO vs WASM/purego.** Resolved: **CGO**.
+  zig-cc cross-compilation in `release.yml` makes this invisible to
+  end users (single static binary per target). WASM revisited only if
+  cross-build itself becomes a maintenance burden.
+- **Q2 — BM25 hand-rolled vs Bleve.** Resolved: **hand-rolled** (`internal/lexical/bm25.go`,
+  ~64 lines). Confirmed in M1 and validated again by PR #5
+  (query-time prefix expansion was a one-file change; not feasible if
+  Bleve owned the index).
+- **Q6 — secrets policy.** Resolved: implemented in
+  `internal/walker/secrets.go`. Basename match (`.env`), prefix match
+  (`.env.*`), extension/keyfile match (`*.pem`, `*.key`, `id_rsa*`,
+  `id_ed25519*`), plus content scanning for AWS access-key prefix and
+  PEM headers. User overrides via `.codemapignore` (gitignore syntax)
+  or `walker.Options.ExtraIgnores` for embedders.
+- **Q7 — monorepo strategy.** Resolved: **per repo root**, with the
+  registry providing the multi-index handle. A user who wants finer
+  granularity runs `codemap init <subdir>` for each subproject;
+  resolution still works because the registry stores absolute paths.
+
+### Still open
+
+- **Q3 — edge resolution depth for dynamic languages.** Currently
+  parsers emit `to_qualname` as the raw text seen at the call site
+  (e.g. `_cleanup` rather than `module._cleanup`). Same-module
+  unqualified references therefore stay unresolved and `refs`/`calls`
+  on the canvas drop them. A short-range resolver (try the current
+  module's prefix, then transitively-imported aliases) would fix the
+  80% case without paying for a real type system. Type-aware analysis
+  is explicitly **not** on the table — it would push codemap out of
+  the "shallow but cheap" bucket and into IDE territory.
+- **Q4 — visualization at scale.** vis-network has been validated up
+  to ~2k nodes / ~2.5k edges (CC-Pilot fixture) with the
+  focused-edge-mode pattern from PR #4 (edges hidden by default,
+  shown only for the selected node). 10k+ is unverified. Likely
+  remediation if it shows up: cytoscape.js with progressive
+  disclosure / community detection, or simply `--file <glob>` to
+  render a slice. No action until a real >5k repo lands as a user
+  report.
+- **Q5 — SKILL spec drift.** Claude Code paths and frontmatter are
+  pinned (`internal/skill/paths.go` + golden test). Codex still
+  pending upstream; `--agent codex` is rejected with a single
+  user-readable line and `--print` still works for manual placement.
+- **Q8 — cross-repo search (`--repo a,b,c`).** Deferred to post-v1.
+  SQL union over multiple stores is mechanical, but BM25 statistics
+  (avgLen, idf) are corpus-local, so the ranking step needs design
+  work before this is honest. Revisit when an actual user has a
+  multi-repo workflow that the per-repo workflow can't cover.
 
 ---
 


### PR DESCRIPTION
## Summary

\`codemap-design.md §15\` listed eight open questions. Five of them
were quietly settled by the v0.1.x implementation but the doc never
caught up. Splits §15 into **Resolved** (points back to §16) and
**Still open** (with the current state).

### Resolved

- **Q1** tree-sitter via CGO — done; zig-cc cross-build hides it from
  end users.
- **Q2** BM25 hand-rolled — done; PR #5's prefix expansion was a
  one-file change because of this choice.
- **Q6** secrets policy — done; \`internal/walker/secrets.go\` covers
  basename / prefix / extension / content patterns, plus
  \`.codemapignore\` user overrides.
- **Q7** monorepo — done; \"per repo root\" with the registry
  providing the multi-index handle.

### Still open with explicit state

- **Q3** edge resolver depth — known buggy on dynamic-language
  internal calls (CC-Pilot evidence). Short-range resolver is the
  next planned step; type-aware analysis explicitly out of scope to
  preserve the \"shallow but cheap\" philosophy.
- **Q4** visualization at scale — validated to ~2k nodes / 2.5k
  edges, 10k+ unverified.
- **Q5** SKILL spec drift — Claude Code pinned, Codex still upstream.
- **Q8** cross-repo search — deferred; per-corpus BM25 statistics
  need design work before the ranking step is honest.

### README touch-up

One sentence under Privacy describing \`.codemapignore\` overrides, in
both EN and KR. Without it the secrets policy reads as immutable.

## Test plan

- [x] No code changes; CI's job is to confirm nothing went sideways.
- [x] Section numbering / cross-refs (§15 ↔ §16) eyeball-checked.