### PR TITLE
Short-range edge resolver: rewrite bare same-module callees

### DIFF
--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -16,7 +16,14 @@ const SchemaVer = 1
 // across a skew, but search results will be stale; the mismatch is
 // surfaced via `codemap status` (Stale=true) rather than failing
 // Open(), so existing scripts keep working until the user reindexes.
-const IndexerVer = 1
+//
+// History:
+//   - 1: initial value introduced alongside indexer_ver tracking.
+//   - 2: short-range edge resolver — bare-name to_qualnames are
+//     rewritten to `<from-module>.<name>` when the prefixed form is a
+//     known symbol. Existing indexes have raw bare names in their
+//     edges table; reindex to refresh.
+const IndexerVer = 2
 
 // schemaSQL is the DDL applied to a fresh database.
 // Statements are separated by semicolons and applied via a single db.Exec call.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -246,6 +246,80 @@ func TestStore_ResolveEdges(t *testing.T) {
 	}
 }
 
+// TestStore_ResolveEdges_ShortRange covers §15 Q3: an edge whose
+// to_qualname is a bare callee name (e.g. `_cleanup` from a Python
+// parser that didn't track the same-module prefix) should be rewritten
+// to `<module>._cleanup` and marked resolved when that qualname exists
+// in the symbols table.
+//
+// External calls like `argparse.ArgumentParser` (which already contain
+// a dot) must NOT be rewritten — the short-range pass only fires on
+// dotless to_qualnames so dotted external chains stay unresolved.
+func TestStore_ResolveEdges_ShortRange(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	err := st.WithTx(ctx, func(tx Tx) error {
+		if err := tx.UpsertFile(core.File{Path: "main.py", SHA1: "h", IndexedAt: now, Language: "python", SizeBytes: 1}); err != nil {
+			return err
+		}
+		if _, err := tx.InsertSymbols([]core.Symbol{
+			{Name: "main", Qualname: "main.main", Kind: core.SymbolFunction, Scope: core.ScopeGlobal, File: "main.py", LineStart: 1, LineEnd: 5},
+			{Name: "_cleanup", Qualname: "main._cleanup", Kind: core.SymbolFunction, Scope: core.ScopeGlobal, File: "main.py", LineStart: 10, LineEnd: 12},
+		}); err != nil {
+			return err
+		}
+		return tx.InsertEdges([]core.Edge{
+			// bare same-module call — should resolve to main._cleanup
+			{FromQualname: "main.main", ToQualname: "_cleanup", Kind: core.EdgeCall, Resolved: false},
+			// dotted external — must stay unresolved
+			{FromQualname: "main.main", ToQualname: "argparse.ArgumentParser", Kind: core.EdgeCall, Resolved: false},
+			// already-resolved exact match — unchanged
+			{FromQualname: "main.main", ToQualname: "main._cleanup", Kind: core.EdgeReference, Resolved: false},
+		}, "main.py")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := st.WithTx(ctx, func(tx Tx) error { return tx.ResolveEdges() }); err != nil {
+		t.Fatal(err)
+	}
+
+	err = st.WithTx(ctx, func(tx Tx) error {
+		edges, err := tx.EdgesFrom("main.main")
+		if err != nil {
+			return err
+		}
+		var resolvedCleanup, resolvedRef bool
+		var argparseStillUnresolved bool
+		for _, e := range edges {
+			switch {
+			case e.ToQualname == "main._cleanup" && e.Resolved && e.Kind == core.EdgeCall:
+				resolvedCleanup = true
+			case e.ToQualname == "main._cleanup" && e.Resolved && e.Kind == core.EdgeReference:
+				resolvedRef = true
+			case e.ToQualname == "argparse.ArgumentParser" && !e.Resolved:
+				argparseStillUnresolved = true
+			}
+		}
+		if !resolvedCleanup {
+			t.Errorf("bare-name edge to `_cleanup` was not rewritten to `main._cleanup`/resolved")
+		}
+		if !resolvedRef {
+			t.Errorf("exact-match edge to `main._cleanup` was not resolved")
+		}
+		if !argparseStillUnresolved {
+			t.Errorf("dotted external `argparse.ArgumentParser` should stay unresolved")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestStore_SearchBM25_Basic(t *testing.T) {
 	st := openTestStore(t)
 	ctx := context.Background()

--- a/internal/store/tx.go
+++ b/internal/store/tx.go
@@ -728,15 +728,144 @@ func (t *txImpl) queryEdges(q, qualname string) ([]core.Edge, error) {
 	return edges, nil
 }
 
-// ResolveEdges sets resolved=1 on every edge whose to_qualname matches a
-// qualname present in the symbols table.
+// ResolveEdges resolves edge endpoints in two passes:
+//
+//  1. Exact match — set resolved=1 on every edge whose to_qualname
+//     matches an existing symbols.qualname verbatim.
+//  2. Short-range rewrite — for each still-unresolved edge whose
+//     to_qualname has no dots (a bare callee name like `_cleanup`),
+//     try prepending the *module prefix* of from_qualname (everything
+//     up to and including the last dot) and check whether that
+//     produces a known qualname. This catches the common case of a
+//     same-module function calling a same-module helper without the
+//     parser tracking aliases or imports.
+//
+// The second pass is intentionally narrow: only bare names (no dots)
+// are rewritten, so we never collapse a dotted chain like
+// `parser.add_argument` into a same-module symbol by accident. Type
+// inference, transitive imports, and aliasing remain explicit
+// non-goals (codemap-design.md §4.3 / §15 Q3).
 func (t *txImpl) ResolveEdges() error {
-	const q = `
+	const exact = `
 UPDATE edges SET resolved = 1
-WHERE to_qualname IN (SELECT qualname FROM symbols)`
+WHERE resolved = 0
+  AND to_qualname IN (SELECT qualname FROM symbols)`
 
-	if _, err := t.tx.ExecContext(t.ctx, q); err != nil {
-		return fmt.Errorf("store.ResolveEdges: %w", err)
+	if _, err := t.tx.ExecContext(t.ctx, exact); err != nil {
+		return fmt.Errorf("store.ResolveEdges (exact): %w", err)
+	}
+
+	// instr(s, '.') gives the 1-based index of the first dot or 0 when
+	// there is none — so "X.Y.func" → 2, "func" → 0. We use the *last*
+	// dot in from_qualname to derive the module prefix, hence rfind via
+	// length - instr(reverse(...)).
+	//
+	// SQLite has no built-in `reverse()` and rolling our own UDF would
+	// require a CGO driver; instead we use a CTE that filters edges
+	// where to_qualname has no dot, joins against symbols on the
+	// concatenation `<module>.<to>`, and rewrites both to_qualname and
+	// resolved in a single UPDATE.
+	const shortRange = `
+WITH candidate AS (
+  SELECT
+    e.rowid AS rid,
+    e.from_qualname AS fq,
+    e.to_qualname AS tq,
+    -- module prefix of from_qualname: everything up to (and
+    -- including) the last dot. "" when from has no dot.
+    CASE
+      WHEN instr(e.from_qualname, '.') = 0 THEN ''
+      ELSE substr(
+        e.from_qualname, 1,
+        length(e.from_qualname)
+          - length(replace_after_last_dot(e.from_qualname))
+      )
+    END AS module_prefix
+  FROM edges e
+  WHERE e.resolved = 0
+    AND instr(e.to_qualname, '.') = 0
+    AND e.to_qualname <> ''
+)
+SELECT 1`
+	// SQLite has no replace_after_last_dot helper; the SQL above is
+	// pseudocode for clarity. We compute the prefix in Go where it's
+	// trivial, then issue one UPDATE per edge that matched. The pass
+	// runs once at the end of an indexing run, so this is fine even
+	// for repos with thousands of unresolved edges.
+	_ = shortRange
+
+	type candidate struct {
+		rowid int64
+		from  string
+		to    string
+	}
+	rows, err := t.tx.QueryContext(t.ctx, `
+SELECT rowid, from_qualname, to_qualname
+FROM edges
+WHERE resolved = 0
+  AND instr(to_qualname, '.') = 0
+  AND to_qualname <> ''`)
+	if err != nil {
+		return fmt.Errorf("store.ResolveEdges (short-range scan): %w", err)
+	}
+	var cands []candidate
+	for rows.Next() {
+		var c candidate
+		if err := rows.Scan(&c.rowid, &c.from, &c.to); err != nil {
+			rows.Close()
+			return fmt.Errorf("store.ResolveEdges scan: %w", err)
+		}
+		cands = append(cands, c)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("store.ResolveEdges rows: %w", err)
+	}
+
+	if len(cands) == 0 {
+		return nil
+	}
+
+	// Cache symbols.qualname presence in a Go map. ~tens of thousands
+	// of qualnames at most; one round-trip is cheaper than per-edge
+	// EXISTS subqueries.
+	known := make(map[string]struct{}, 1024)
+	qrows, err := t.tx.QueryContext(t.ctx, `SELECT qualname FROM symbols`)
+	if err != nil {
+		return fmt.Errorf("store.ResolveEdges (load qualnames): %w", err)
+	}
+	for qrows.Next() {
+		var q string
+		if err := qrows.Scan(&q); err != nil {
+			qrows.Close()
+			return fmt.Errorf("store.ResolveEdges qn scan: %w", err)
+		}
+		known[q] = struct{}{}
+	}
+	qrows.Close()
+	if err := qrows.Err(); err != nil {
+		return fmt.Errorf("store.ResolveEdges qn rows: %w", err)
+	}
+
+	updateStmt, err := t.tx.PrepareContext(t.ctx,
+		`UPDATE edges SET to_qualname = ?, resolved = 1 WHERE rowid = ?`)
+	if err != nil {
+		return fmt.Errorf("store.ResolveEdges prepare: %w", err)
+	}
+	defer updateStmt.Close()
+
+	for _, c := range cands {
+		dot := strings.LastIndex(c.from, ".")
+		if dot < 0 {
+			continue
+		}
+		candidate := c.from[:dot+1] + c.to
+		if _, ok := known[candidate]; !ok {
+			continue
+		}
+		if _, err := updateStmt.ExecContext(t.ctx, candidate, c.rowid); err != nil {
+			return fmt.Errorf("store.ResolveEdges update rowid=%d: %w", c.rowid, err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Closes the concrete part of design.md §15 Q3 surfaced by CC-Pilot:
the Python parser emits \`to_qualname\` as the raw text at the call
site (e.g. \`_cleanup\`) instead of the resolved qualname
(\`main._cleanup\`), so same-module edges never matched a known symbol
and the visualize canvas ended up with zero internal arrows.

\`ResolveEdges\` now runs in two passes:

1. **Exact match** (unchanged) — \`UPDATE edges SET resolved=1 WHERE
   to_qualname IN (SELECT qualname FROM symbols)\`.
2. **Short-range rewrite** (new) — for each still-unresolved edge
   whose \`to_qualname\` has no dot, prepend the module prefix of
   \`from_qualname\` and check whether that produces a known qualname.
   If so, rewrite \`to_qualname\` to the prefixed version and set
   \`resolved=1\`.

## What stays explicitly out of scope

- Dotted chains like \`argparse.ArgumentParser\` — external by
  construction, stay unresolved (visualize already shows them as
  external placeholder nodes from PR #4).
- Type inference, transitive imports, aliasing — these would push
  codemap from \"shallow but cheap\" toward an IDE, which the
  philosophy bullet in README explicitly disclaims.

The narrow scope means the pass is trivially safe: by construction it
only writes a value that is already a key in \`symbols.qualname\`, so
it can't introduce a stale or invented edge target.

## Implementation note

SQLite has no built-in \`reverse()\` and adding a CGO UDF would be
heavyweight, so the rewrite runs in Go: one round-trip to load every
\`symbols.qualname\` into a map, one prepared UPDATE per matched
candidate. The pass runs once at the end of an indexing run; cost is
linear in the unresolved-edge count and irrelevant next to parsing.

## Test plan

- [x] \`go test ./internal/store/... -run TestStore_ResolveEdges -v\`
      — both \`TestStore_ResolveEdges\` (existing) and the new
      \`TestStore_ResolveEdges_ShortRange\` pass.
- [x] All other CGO-free packages green
      (pipeline, cli, lexical, visualize).
- [ ] CI on full matrix (Linux/macOS/Windows + tree-sitter CGO).
- [ ] Manual: after merge + v0.1.3 release, reindex CC-Pilot and
      verify the \`bothIn\` count in vizcheck output (or simply the
      visualize canvas) shows real internal arrows. Expect a sharp
      drop in unresolved counts.

## Note on indexer_ver (PR #8)

This change updates how stored \`to_qualname\` values look — same
schema, different content. Once PR #8 lands and we cut a release
that bumps \`IndexerVer\` to 2, existing indexes will report
\`stale=true\` until reindexed, which is exactly the intent.