### PR TITLE
docs: round-4 sweep across design.md, architecture.md, READMEs

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -97,7 +97,8 @@ Python + 6 개 언어 파서 (Java, JavaScript, TypeScript, TSX, C#, C++),
 go build ./cmd/codemap
 ```
 
-선택적 encoder rerank (v1 은 placeholder, M5 에서 ONNX 통합):
+선택적 encoder rerank (v0.1.x 은 placeholder; ONNX 결선은
+`internal/encoder/onnx_enabled.go` 한 파일 교체로 가능):
 
 ```sh
 go build -tags encoder ./cmd/codemap
@@ -208,7 +209,7 @@ codemap install-skill --agent claude-code --scope user
    │
    ▼
 walker → parser (tree-sitter) → lexical (BM25) → store (SQLite)
-                                 └─ encoder rerank (옵션, M5)
+                                 └─ encoder rerank (옵션, build-tag)
 ```
 
 - CLI 프로세스는 단발성입니다. 매 호출마다 SQLite 파일을 새로 엽니다.
@@ -260,6 +261,7 @@ internal/
   graph/                     # refs + calls
   visualize/                 # graph.html 렌더
   skill/                     # SKILL.md 설치기
+  install/                   # codemap install-self / uninstall-self
   platform/                  # OS 추상화 (path, atomic write, browser)
 skill/SKILL.md.tmpl          # SKILL.md 템플릿 원본
 scripts/                     # zig-cc wrapper (릴리스 타깃별)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Requires **Go 1.25+** and a **C toolchain** (CGO is enabled by tree-sitter).
 go build ./cmd/codemap
 ```
 
-For optional encoder rerank support (placeholder in v1, ONNX in M5):
+For optional encoder rerank support (placeholder in v0.1.x; the
+ONNX session wiring is a one-file swap in `internal/encoder/onnx_enabled.go`):
 
 ```sh
 go build -tags encoder ./cmd/codemap
@@ -210,7 +211,7 @@ the public contract — see `architecture.md` §6.2.
    │
    ▼
 walker → parser (tree-sitter) → lexical (BM25) → store (SQLite)
-                                 └─ encoder rerank (optional, M5)
+                                 └─ encoder rerank (optional, build-tag)
 ```
 
 - The CLI process is short-lived; every invocation re-opens the SQLite file.
@@ -264,6 +265,7 @@ internal/
   graph/                     # refs + calls
   visualize/                 # graph.html renderer
   skill/                     # SKILL.md installer
+  install/                   # codemap install-self / uninstall-self
   platform/                  # OS abstraction (paths, atomic write, browser)
 skill/SKILL.md.tmpl          # canonical SKILL.md template
 scripts/                     # zig-cc wrapper scripts (one per release target)

--- a/architecture.md
+++ b/architecture.md
@@ -53,13 +53,12 @@
 └──────────┬──────────────────────────────┬───────────────────────┘
            │                              │
            ▼                              ▼
-┌──────────────────────┐         ┌──────────────────────────┐
-│ ~/.codemap/          │         │ <repo>/.codemap/         │
-│   registry.toml      │         │   index.db    (SQLite)   │
-│   state.toml (opt)   │         │   meta.json   (mirror)   │
-│                      │         │   config.toml (opt)      │
-│                      │         │   graph.html  (visualize)│
-└──────────────────────┘         └──────────────────────────┘
+┌──────────────────────────────┐ ┌──────────────────────────┐
+│ ~/.codemap/                  │ │ <repo>/.codemap/         │
+│   registry.toml              │ │   index.db    (SQLite)   │
+│   state.toml          (opt)  │ │   graph.html  (visualize)│
+│   bin/codemap{,.exe}  (opt)  │ │                          │
+└──────────────────────────────┘ └──────────────────────────┘
 ```
 
 - A new process is spawned per invocation (no daemon). Therefore **all state
@@ -201,7 +200,7 @@ codemap/
 ### 2.1 Dependency Rules (enforced)
 
 ```
-cli ──► search / pipeline / graph / visualize / skill / registry
+cli ──► search / pipeline / graph / visualize / skill / install / registry
         │
         ▼
    store ◄── pipeline, search, graph, visualize
@@ -210,6 +209,7 @@ cli ──► search / pipeline / graph / visualize / skill / registry
    lexical ◄── pipeline (write), search (read)
    encoder ◄── search (optional, build tag)
    registry ◄── cli, pipeline, search
+   install ◄── cli            (codemap install-self / uninstall-self)
    core    ◄── (importable from anywhere; depends on nothing internal)
    platform ◄── almost every module
 ```
@@ -455,22 +455,26 @@ wrapping.
 - **Public surface.**
   ```go
   type IndexOptions struct {
-      Force      bool   // reindex
-      Concurrency int   // parser workers
-      Encoder    encoder.Encoder // optional
+      Force       bool             // reindex
+      Concurrency int              // parser workers; defaults to runtime.NumCPU()
+      Encoder     encoder.Encoder  // optional
+      Progress    io.Writer        // human-readable progress (defaults to os.Stderr)
   }
 
   type Summary struct {
-      ParsedFiles  int
-      SkippedFiles int
-      Symbols      int
-      Edges        int
+      Parsed       int           // files (re-)parsed in this run
+      Skipped      int           // unchanged-SHA1 or parse-error skips
+      Removed      int           // files deleted from disk and from the index
+      Symbols      int           // symbols inserted in this run
+      Edges        int           // edges inserted in this run
+      TotalSymbols int           // cumulative symbol count after this run
+      TotalFiles   int           // cumulative file count after this run
       Duration     time.Duration
       IndexedAt    time.Time
   }
 
-  func Index(ctx context.Context, repoRoot string, opts IndexOptions) (Summary, error)
-  func Reindex(ctx context.Context, repoRoot string, opts IndexOptions) (Summary, error)
+  func Index(ctx context.Context, st *store.Store, repoRoot string, opts IndexOptions) (Summary, error)
+  func Reindex(ctx context.Context, st *store.Store, repoRoot string, opts IndexOptions) (Summary, error)
   ```
 - **Transaction boundary.** A single transaction per "set of changed files":
   `DELETE FROM symbols/edges/tokens WHERE file IN (...)` → INSERT new data →
@@ -518,13 +522,31 @@ wrapping.
 
 ### 3.11 `visualize`
 
-- **Responsibility.** Render `graph.html`. Single static file output. Loads
-  `vis-network` / `cytoscape.js` from a CDN at view time. Header shows
-  `lastIndexed`, repo path, node/edge counts (design §9.7).
+- **Responsibility.** Render `graph.html`. Single static file output.
+  Loads `vis-network` from a CDN at view time. The header shows
+  `lastIndexed`, repo path, and node/edge counts (design §9.7); the
+  body adds a floating search box, focus-mode edges (only the
+  selected node's edges are drawn), an aside detail panel with
+  grouped outgoing references, dark mode, and selection-history nav
+  with camera follow.
 - **Public surface.**
   ```go
-  type Options struct { OutPath string; Open bool }
-  func Render(ctx, store, opts Options) (path string, err error)
+  type Options struct {
+      OutPath  string                // defaults to <repo>/.codemap/graph.html
+      Open     bool                  // open in OS default browser when set
+      FileGlob string                // forward-slash doublestar glob
+      Kinds    []core.SymbolKind     // limit symbols by kind
+  }
+
+  // DataSource is the read-only contract visualize needs from the
+  // index. store.Tx implements it; the call site provides the adapter.
+  type DataSource interface {
+      AllSymbols(ctx context.Context, fileGlob string, kinds []core.SymbolKind) ([]core.Symbol, error)
+      AllEdges(ctx context.Context) ([]core.Edge, error)
+      ReadMeta() (core.Meta, error)
+  }
+
+  func Render(ctx context.Context, ds DataSource, repoRoot string, opts Options) (path string, err error)
   ```
 
 ### 3.12 `skill`
@@ -534,10 +556,16 @@ wrapping.
 - **Public surface.**
   ```go
   type Target struct {
-      Agent string  // "claude-code" | "codex"
-      Scope string  // "user" | "project"
-      Repo  string  // used when scope == "project"
+      Agent      string  // "claude-code" | "codex"
+      Scope      string  // "user" | "project"
+      Repo       string  // used when scope == "project"
+      BinaryName string  // substituted into SKILL body; defaults to "codemap"
+      Version    string  // substituted into SKILL body
   }
+  // ErrCodexPending is returned when Agent == "codex"; the cli layer
+  // detects it via errors.Is and prints a single user-readable line.
+  var ErrCodexPending = errors.New("codex skill spec pending; verify at release time")
+
   func Install(t Target, print bool) (path string, err error)
   func Uninstall(t Target) error
   ```
@@ -546,8 +574,38 @@ wrapping.
 
 - **Responsibility.** Register cobra commands, parse flags, call into the
   domain, format output. **No logic of its own.**
+- **Subcommand surface (v0.1.x).** init, index, reindex, list, status,
+  forget, search, show, refs, calls, visualize, install-skill,
+  uninstall-skill, install-self, uninstall-self, version. The
+  install-self / uninstall-self pair lives in `install_self.go` and
+  is the only cli handler that calls into the `internal/install`
+  package.
 - **Output formatting.** `output.go` exposes `WriteHuman` and `WriteJSON`.
   All result types are either `core.*` directly or thin CLI view-models.
+
+### 3.13a `install`
+
+- **Responsibility.** Implement `codemap install-self` / `uninstall-self`.
+  Copy the running binary to `~/.codemap/bin/codemap{,.exe}` and
+  register that directory on the user's persistent PATH. Mirror image
+  on uninstall. No admin rights anywhere.
+- **Public surface.**
+  ```go
+  type Result struct {
+      BinaryPath           string
+      BinaryCopied         bool   // a fresh copy happened this run
+      PathAdded            bool   // PATH entry created (or removed)
+      ShellRCPath          string // Unix only; rc file we touched
+      PathAlreadyEffective bool   // bin dir is on the running shell's PATH
+  }
+  func InstallSelf(selfPath string) (Result, error)
+  func UninstallSelf() (Result, error)
+  ```
+- **Platform split.** Windows writes `HKCU\Environment\Path` and
+  broadcasts `WM_SETTINGCHANGE` (`path_windows.go`). Unix appends a
+  marker block to the shell rc detected from `$SHELL`
+  (`path_unix.go`); the marker lets uninstall remove exactly the
+  inserted block.
 
 ### 3.14 `platform`
 
@@ -614,9 +672,16 @@ registry.Upsert(mirror)
 output.WriteHuman/JSON(Summary)   # files indexed/skipped, lastIndexed
 ```
 
-- **Edge resolution (`Edge.Resolved`).** First pass resolves only same-file
-  call sites. Cross-file resolution runs once after all files are parsed,
-  inside the same transaction (qualname → symbol_id lookup).
+- **Edge resolution (`Edge.Resolved`).** Runs once at the end of the
+  indexing transaction in `store.Tx.ResolveEdges()`:
+  1. Exact-match pass — `to_qualname` that equals an existing
+     `symbols.qualname` is marked `resolved=1`.
+  2. Short-range rewrite — for each still-unresolved edge whose
+     `to_qualname` has no dot, prepend the module prefix of
+     `from_qualname`; if that produces a known qualname, rewrite
+     `to_qualname` and mark `resolved=1`. Catches the common
+     same-module bare-name call (PR #11). Type-aware analysis stays
+     out of scope.
 - **Failure handling.** A parse error on one file does **not** fail the run.
   The file is isolated, logged, and *its* SHA-1 is not updated, so it gets
   retried next time. A transaction-level error rolls back the whole run.
@@ -657,21 +722,50 @@ Unresolved edges (`Resolved=false`) appear in the result set, marked.
 
 ```
 visualize.Render
-   ├─ store: fetch all symbols / edges (with optional --file or --kind filters)
+   ├─ ds.AllSymbols(fileGlob, kinds) / ds.AllEdges() / ds.ReadMeta()
+   ├─ build graphNodes (dedupe by qualname, attach locations + snippet
+   │   + outgoing edges per node)
+   ├─ for any edge whose to-endpoint is not in the node set, synthesize
+   │   an "external" placeholder node so unresolved/stdlib calls are
+   │   still visible on the canvas
    ├─ inject pre-marshaled JSON into graph.html.tmpl via embed.FS
    └─ atomic-write <repo>/.codemap/graph.html → open in browser if --open
 ```
 
-Large graphs (10k+ nodes) are deferred to design Open Question 4 — v1 just
-renders, with filters as the escape hatch.
+Large graphs (10k+ nodes) are deferred to design Open Question 4 —
+v0.1.x relies on focus-mode edges (drawn only for the selected node)
+plus the `--file` / `--kind` escape hatches.
 
-### 4.6 `codemap install-skill`
+### 4.6 `codemap install-skill` and `codemap install-self`
+
+`install-skill` writes the SKILL.md template:
 
 ```
 skill.Install({Agent, Scope, Repo}, print):
    path := skill.paths.Resolve(target)   // e.g. ~/.claude/skills/codemap/SKILL.md
    body := template.Execute(SKILL.md.tmpl, {Version, BinaryName, …})
    if print: stdout
+   else:     platform.AtomicWrite(path, body)
+
+# Codex target → ErrCodexPending → cli prints a single-line help.
+```
+
+`install-self` is the post-download PATH bootstrapper:
+
+```
+install.InstallSelf(selfPath):
+   platform.EnsureDir(~/.codemap/bin)
+   if !sameFile(selfPath, dest) && !destMatchesSrc(selfPath, dest):
+       atomic copy selfPath → ~/.codemap/bin/codemap{,.exe}
+       preserve src mtime so subsequent runs are no-ops
+   addToPath(~/.codemap/bin):
+       Windows: HKCU\Environment\Path += dir; SendMessageTimeout WM_SETTINGCHANGE
+       Unix:    append marker block to ~/.bashrc / ~/.zshrc / config.fish / ~/.profile
+   return Result{BinaryCopied, PathAdded, ShellRCPath, PathAlreadyEffective}
+```
+
+Idempotent in both directions; `uninstall-self` strips exactly the
+binary and the PATH entry the install pass created.
    else: platform.AtomicWrite(path, body)
 ```
 
@@ -866,11 +960,11 @@ This is a stable contract so an agent can branch on the exit code of
 
 | Area | Policy |
 |---|---|
-| Parser workers | Default `runtime.NumCPU()`, override with `--concurrency N` |
+| Parser workers | Default `runtime.NumCPU()`, capped at 16. Set programmatically through `pipeline.IndexOptions.Concurrency`; not exposed as a CLI flag in v0.1.x. |
 | DB writer | Single goroutine (SQLite single writer); fed via channel |
 | File I/O | Walker streams; no full tree held in memory |
 | Memory ceiling | Per-file parse output is held in memory only until the transaction commits, then released |
-| Large files | Files > 1 MiB are skipped by default (configurable) — protects token spend |
+| Large files | Files > 1 MiB are skipped by default. Configurable internally via `walker.Options.MaxFileBytes`; not yet a CLI flag. |
 | Goroutine leaks | Context cancellation propagates to walker, parser, and writer |
 | WAL mode | `journal_mode=WAL` allows reader/writer concurrency (e.g. `status` reads while `index` writes) |
 

--- a/codemap-design.md
+++ b/codemap-design.md
@@ -121,7 +121,8 @@ Implications that shape every decision below:
 - **Not a generative LLM.** Specialized encoder; query-time inference is
   <100 ms on CPU, batchable.
 - Used only as a **re-ranker** over L0's top-50, narrowing to top-10.
-- Activation: `--rerank` flag or `.codemap/config.toml` setting.
+- Activation: `--rerank` flag on `codemap search`. There is no
+  per-repo config file in v0.1.x; CLI flags are the only knob.
 
 ### 4.3 What is explicitly excluded
 
@@ -253,7 +254,7 @@ enables:
 
 - `codemap list` from anywhere.
 - `codemap search foo --repo myproject` from anywhere.
-- Cross-repo search later (M5+, optional): `codemap search foo --repo a,b,c`.
+- Cross-repo search later (post-v1; tracked in §15 Q8): `codemap search foo --repo a,b,c`.
 - Visibility into stale indexes (`last_indexed` older than N days).
 
 ---
@@ -375,9 +376,13 @@ Symbol        id
               vec?        # only if encoder enabled
 
 Edge          from_qualname
-              to_qualname        # may be unresolved name
+              to_qualname        # may be an unresolved bare name; the
+                                 # short-range resolver in store rewrites
+                                 # bare same-module callees in place
               kind               # call | reference | inherit | import
               resolved : bool
+              file               # source file the edge was discovered in;
+                                 # used by per-file cascading delete
 ```
 
 **Variable mapping (R4) rules.**
@@ -422,11 +427,21 @@ transaction. Bumps `Meta.indexed_at`.
 Single-file SQLite per repo (§7.1). One global registry TOML.
 
 ### 9.5 Search
-1. Detect query shape (identifier-like vs. natural language).
-2. BM25 over `tokens` → top-50 with structural filters.
-3. If `--rerank` and encoder available: dense re-rank → top-10.
+1. Tokenize the query the same way the index was built (CamelCase /
+   snake_case split, lowercased). Short query terms (≥ 3 chars) are
+   prefix-expanded against stored tokens so e.g. `parse` matches
+   stored `parser`/`parsed` (PR #5; `tokens.token LIKE 'parse%'`).
+2. BM25 over `tokens` → top-50 with structural filters
+   (`--kind`, `--scope`, `--file`).
+3. If `--rerank` and an encoder is available: dense re-rank against
+   `symbols.vec` → top-10.
 4. Emit JSON:
    `[{file, line_start, line_end, qualname, kind, scope, snippet, score, indexed_at}]`.
+
+There is no separate "natural language vs identifier" path inside
+codemap — every query goes through the same lexical pipeline.
+Translating prose into identifier-shaped queries is the agent's job
+(see §4.4 / SKILL.md).
 
 ### 9.6 Graph queries — `refs` (incoming) and `calls` (outgoing)
 Symmetric pair, both backed by the `edges` table.
@@ -437,9 +452,12 @@ This pair is what makes the example query "what functions does
 `main.init` call?" answerable in one round trip.
 
 ### 9.7 Visualizer
-Single static `graph.html`. One CDN dep at view time (vis-network or
-cytoscape.js). Header shows `lastIndexed`, repo path, node/edge counts.
-Filters: kind, scope, file glob.
+Single static `graph.html`. One CDN dep at view time (vis-network).
+Header shows `lastIndexed`, repo path, and node/edge counts; v0.1.x
+also adds a floating search box, focus-mode edges (drawn only for
+the selected node), an aside detail panel with grouped outgoing
+references, dark mode, and selection-history nav with camera
+follow. Render-time filters: `--file` glob, `--kind` set.
 
 ---
 


### PR DESCRIPTION
## Summary

Section-by-section pass against the v0.1.4 binary, bringing the
four docs in line with the current implementation. Doc-only PR;
no code changes.

### design.md
- §4.2 rerank activation: \`--rerank\` flag only; no per-repo config
  file in v0.1.x.
- §8 Edge gains the \`file\` field that drives per-file cascading
  delete.
- §9.5 Search rewrote to describe the actual lexical pipeline
  (CamelCase split, prefix expansion ≥ 3 chars, BM25 + filters,
  optional dense rerank), with NL → identifier translation
  delegated to the agent (§4.4).
- §9.7 Visualizer scoped to vis-network and lists the v0.1.x UX
  additions (search box, focus-mode edges, aside detail panel,
  dark mode, history nav with camera follow).
- §6.4 cross-repo search relabelled \"post-v1; tracked in §15 Q8\".

### architecture.md
- §1 context diagram: \`~/.codemap/\` shows registry / state / bin;
  per-repo tree shows index.db and graph.html.
- §2.1 dependency rules adds the \`install\` package.
- §3.8 pipeline signatures take \`*store.Store\`; \`Summary\` lists
  the nine fields the binary returns; \`IndexOptions.Progress\`
  documented.
- §3.11 visualize: vis-network only, v0.1.x UX features, real
  \`Options\` / \`Render\` shape with the \`DataSource\` interface.
- §3.12 skill \`Target\` adds \`BinaryName\` / \`Version\`;
  \`ErrCodexPending\` documented.
- §3.13 cli enumerates subcommands; install-self / uninstall-self
  noted as living in \`install_self.go\`.
- New §3.13a documents the \`install\` package public surface.
- §4.2 indexing flow describes the two-pass resolver (exact match
  + short-range bare-name rewrite).
- §4.5 visualize describes node dedupe + external placeholder
  synthesis.
- §4.6 split into install-skill plus a new install-self block.
- §7 documents that concurrency / large-file knobs are internal
  options today, not CLI flags.

### README.md / README-ko.md
- \`go build -tags encoder\` blurb points at
  \`internal/encoder/onnx_enabled.go\` instead of mentioning M5.
- Architecture diagram annotation moved from \"M5\" to
  \"build-tag\".
- Repository Layout adds \`internal/install/\`.

## Test plan
- [x] No code; CI just confirms nothing else regresses.
- [x] grep across the four docs for \`M5\`, \`config.toml\`,
      \`meta.json\`, \`cytoscape\`, \`--concurrency\`, \`mattn\` —
      remaining matches are decision-summary context only.
- [x] Cross-checked every claim against the v0.1.4 binary, the
      \`internal/\` tree, and on-disk paths under \`~/.codemap/\` and
      a real repo's \`.codemap/\`.